### PR TITLE
feat(calculus): add linearity rules for symbolic integration

### DIFF
--- a/examples/definite_integral_demo.rs
+++ b/examples/definite_integral_demo.rs
@@ -1,0 +1,21 @@
+use rssn::{
+    Expr, definite_integrate, output::typst::to_typst, parse_expr,
+    prelude::numeric_evaluate_numerical,
+};
+
+fn main() {
+    let expr = parse_expr("-x^2 + 1").unwrap().1;
+
+    let result = definite_integrate(
+        &expr,
+        "x",
+        &Expr::new_constant(-1.),
+        &Expr::new_constant(1.),
+    );
+
+    println!(
+        "{} = {:?}",
+        to_typst(&result),
+        numeric_evaluate_numerical(&result)
+    );
+}

--- a/src/symbolic/calculus.rs
+++ b/src/symbolic/calculus.rs
@@ -2258,6 +2258,36 @@ pub(crate) fn integrate_by_rules(
 
             None
         },
+        // Linearity rules: Add, Sub, Neg, and constant multiple (Mul)
+        | Expr::Add(a, b) => {
+            Some(Expr::new_add(
+                integrate(a, var, None, None),
+                integrate(b, var, None, None),
+            ))
+        },
+        | Expr::Sub(a, b) => {
+            Some(Expr::new_sub(
+                integrate(a, var, None, None),
+                integrate(b, var, None, None),
+            ))
+        },
+        | Expr::Neg(a) => Some(Expr::new_neg(integrate(a, var, None, None))),
+        | Expr::Mul(a, b) => {
+            // Constant multiple rule: ∫ c·f(x) dx = c·∫ f(x) dx
+            if let Expr::Constant(_) | Expr::BigInt(_) | Expr::Rational(_) = &**a {
+                if !contains_var(a, var) {
+                    return Some(Expr::new_mul(a.as_ref().clone(), integrate(b, var, None, None)));
+                }
+            }
+
+            if let Expr::Constant(_) | Expr::BigInt(_) | Expr::Rational(_) = &**b {
+                if !contains_var(b, var) {
+                    return Some(Expr::new_mul(b.as_ref().clone(), integrate(a, var, None, None)));
+                }
+            }
+
+            None
+        },
         | _ => None,
     }
 }

--- a/tests/definite_integral_parsed_test.rs
+++ b/tests/definite_integral_parsed_test.rs
@@ -1,0 +1,45 @@
+use rssn::{
+    Expr, definite_integrate, output::typst::to_typst, parse_expr,
+    prelude::numeric_evaluate_numerical,
+};
+
+#[test]
+fn test_definite_integral_parsed_expressions() {
+    let test_cases: Vec<(&str, f64)> = vec![
+        ("x^2", 2.0 / 3.0),
+        ("x^2+1", 8.0 / 3.0),
+        ("1-x^2", 4.0 / 3.0),
+        ("-x^2+1", 4.0 / 3.0),
+    ];
+
+    for (input, expected) in &test_cases {
+        let expr = parse_expr(input).unwrap().1;
+
+        let result = definite_integrate(
+            &expr,
+            "x",
+            &Expr::new_constant(-1.),
+            &Expr::new_constant(1.),
+        );
+
+        let numerical = numeric_evaluate_numerical(&result)
+            .unwrap_or_else(|| panic!("Failed to numerically evaluate integral of '{}'", input));
+
+        assert!(
+            (numerical - expected).abs() < 1e-10,
+            "Integral of '{}' from -1 to 1: expected {}, got {}",
+            input,
+            expected,
+            numerical
+        );
+
+        // Also verify typst output is non-empty
+        let typst = to_typst(&result);
+
+        assert!(
+            !typst.is_empty(),
+            "Typst output for '{}' should not be empty",
+            input
+        );
+    }
+}


### PR DESCRIPTION
- Implement integration for Add, Sub, Neg expressions recursively
- Support constant multiple rule in Mul expressions during integration
- Skip integration when variable is contained in constant factors
- Add test cases for definite integration over -1 to 1 interval
- Include example demonstrating definite integration and numerical evaluation
- Verify that Typst output for integrals is correctly generated and non-empty